### PR TITLE
Update Go 1.26.x/1.27.x, GitHub Actions, go.mod Go 1.26, dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x, 1.27.x]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Install staticcheck

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bep/debounce
 
-go 1.25
+go 1.26


### PR DESCRIPTION
Updates: Go 1.26.x/1.27.x, GitHub Actions, go.mod Go 1.26, dependencies

---
Created by mygithelper